### PR TITLE
Upgrade dependencies and switch from alga to simba

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ name = "implicit3d"
 path = "src/lib.rs"
 
 [dependencies]
-nalgebra = "0.22"
-alga = "0.9"
-stl_io = "0.5"
-bbox = "0.11"
-num-traits = "0.2"
+bbox = "0.11.2"
+nalgebra = "0.27.1"
+num-traits = "0.2.14"
+simba = "0.5.1"
+stl_io = "0.6.0"
 
 [dev-dependencies]
-bencher = "0.1"
-approx = "0.3"
+bencher = "0.1.5"
+approx = "0.5.0"
 
 [[bench]]
 name = "objects"
@@ -33,3 +33,6 @@ harness = false
 [badges]
 travis-ci = { repository = "hmeyer/implicit3d", branch = "master" }
 codecov = { repository = "hmeyer/implicit3d", branch = "master", service = "github" }
+
+[patch.crates-io]
+bbox = { git = "https://github.com/dflemstr/bbox.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "implicit3d"
-version = "0.14.2"
+version = "0.15.0"
 authors = ["Henning Meyer <tutmann@gmail.com>"]
 edition = "2018"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@ pub use bbox::BoundingBox;
 use num_traits::Float;
 use std::fmt::Debug;
 
-/// A Combination of alga::general::RealField and na::RealField.
-pub trait RealField: alga::general::RealField + na::RealField {}
+/// A Combination of `simba::scalar::RealField` and `na::RealField`.
+pub trait RealField: simba::scalar::RealField + na::RealField {}
 impl RealField for f64 {}
 impl RealField for f32 {}
 

--- a/src/transformer.rs
+++ b/src/transformer.rs
@@ -86,7 +86,7 @@ impl<S: RealField + Float + From<f32>> AffineTransformer<S> {
             Some(ref t_inv) => {
                 let bbox = o.bbox().transform(t_inv);
                 let transposed3x3 = t
-                    .fixed_slice::<::na::core::dimension::U3, ::na::core::dimension::U3>(0, 0)
+                    .fixed_slice::<3, 3>(0, 0)
                     .transpose();
                 AffineTransformer {
                     object: o,

--- a/src/twister.rs
+++ b/src/twister.rs
@@ -62,7 +62,7 @@ impl<S: RealField + Float + ::num_traits::FloatConst + From<f32>> Twister<S> {
     fn twist_point(&self, p: &na::Point3<S>) -> na::Point3<S> {
         let p2 = ::na::Point2::new(p.x, p.y);
         let angle = p.z * self.height_scaler;
-        type Rota<S> = ::na::Rotation<S, ::na::U2>;
+        type Rota<S> = ::na::Rotation<S, 2>;
         let trans = Rota::new(angle);
         let rp2 = trans.transform_point(&p2);
         na::Point3::new(rp2.x, rp2.y, p.z)


### PR DESCRIPTION
The `alga` crate is deprecated and has been replaced by `simba`.  This PR also allows the introduction of a much newer `nalgebra` version which is pretty significant.

Depends on https://github.com/hmeyer/bbox/pull/3 for now, after which the `[patch]` section will be removed