### PR TITLE
Add GitHub Actions workflow for publishing to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow that automatically publishes the crate to crates.io when a version tag is pushed.

## Key Changes
- Added `.github/workflows/publish.yml` workflow file that:
  - Triggers on pushes of version tags (matching `v*` pattern)
  - Checks out the code and installs the stable Rust toolchain
  - Builds the project and runs tests to ensure quality before publishing
  - Publishes the crate to crates.io using the `CARGO_REGISTRY_TOKEN` secret

## Implementation Details
- The workflow uses `dtolnay/rust-toolchain@stable` for consistent Rust toolchain management
- Verbose output is enabled for build and test steps for better visibility
- The `CARGO_REGISTRY_TOKEN` secret must be configured in the repository settings for the publish step to succeed
- The workflow only runs on version tags, preventing accidental publishes from regular commits

https://claude.ai/code/session_01DiGmfwBD4x6Scp4bJPgaMw