### PR TITLE
Enable manual triggering of publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish to crates.io
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
## Summary
Added support for manual workflow dispatch to the publish workflow, allowing the crates.io publication process to be triggered manually in addition to the existing automatic tag-based trigger.

## Changes
- Added `workflow_dispatch:` trigger to the publish workflow, enabling manual execution via GitHub Actions UI or API

## Details
This change allows maintainers to manually trigger the publish workflow without requiring a git tag push, providing more flexibility in the release process while maintaining the existing automatic publication on version tags.

https://claude.ai/code/session_01UZUz35CsDCXgfoC293KeJh