### PR TITLE
Bump version to 0.16.0 and update edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "implicit3d"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Henning Meyer <tutmann@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 description = "3d implicit geometry."
 repository = "https://github.com/hmeyer/implicit3d"


### PR DESCRIPTION
## Summary
Updated project metadata to reflect a new release and modernize the Rust edition.

## Key Changes
- Bumped version from 0.15.0 to 0.16.0
- Updated Rust edition from 2021 to 2024

## Notes
These are metadata-only changes to `Cargo.toml`. No source code modifications are included in this update.

https://claude.ai/code/session_01C9x5DSqperyYWqMB2L8wun